### PR TITLE
Use new PurpleAir API

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ on how AQI is calculated as well as the AQI level tables.
 
 ## Usage
 To use this script you'll need a sensor ID, which can be gotten from the
-[PurpleAir map](https://www.purpleair.com/map). Find your favorite sensor, click on it
-to bring up the sensor popup. At the bottom of the popup is a "Get This Widget" link
-which will pop up another thing when you hover over it, click the "JSON" link.
+[PurpleAir map](https://www.purpleair.com/map). Find your favorite sensor,
+click on it to bring up the sensor popup. Toward  the bottom of the popup is a
+"Get This Widget" link, click it.
 
-That will take you to a URL like `https://www.purpleair.com/json?key=<key>&show=<id>`. 
+That will take you to a URL like `https://www.purpleair.com/sensorlist?key=<key>&show=<id>`. 
 The `<id>` is what you'll need to set as an environment variable to configure the
 script.
 
@@ -30,6 +30,13 @@ Docker container.
 ### `PAS_SENSOR_IDS` (required)
 Comma-separated list of IDs of the sensors to scrape, gotten from the PurpleAir /json
 URL for your sensor
+
+### `PAS_API_TOKEN` (required)
+This is the API token that you need to make requests to the API. 
+
+There's probably an official way to get one, but they also give you one when
+you look at the map in a browser. If you open up Developer Tools and watch the
+network requests, you'll see some requests that have a `token` query param.
 
 ### `PAS_LOGGING`
 Log level of the script, defaults to 'info', accepts any [Python logging level

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ This is the API token that you need to make requests to the API.
 There's probably an official way to get one, but they also give you one when
 you look at the map in a browser. If you open up Developer Tools and watch the
 network requests, you'll see some requests that have a `token` query param.
+That `token` is your API token. Don't worry about whether or not it's
+URL-quoted, we'll take care of dealing with that.
 
 ### `PAS_LOGGING`
 Log level of the script, defaults to 'info', accepts any [Python logging level

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "purple-air-scraper"
-version = "0.1.0"
+version = "0.2.0"
 description = "PurpleAir Scraper"
 authors = ["Nick Pegg <nick@nickpegg.com>"]
 license = "MIT"


### PR DESCRIPTION
The old API we were using (www.purpleair.com/json) now returns a HTTP 500. It
looks like they're migrating to a new API (api.purpleair.com) so we should use
that instead.
